### PR TITLE
Remove glib

### DIFF
--- a/p2panda-rs/Cargo.toml
+++ b/p2panda-rs/Cargo.toml
@@ -26,7 +26,7 @@ crate-type = ["cdylib", "rlib"]
 test-utils = ["storage-provider", "dep:rstest", "dep:rstest_reuse", "dep:varu64", "dep:tokio", "dep:async-trait"]
 secret-group = ["dep:openmls", "dep:openmls_memory_keystore", "dep:openmls_rust_crypto", "dep:openmls_traits", "dep:tls_codec"]
 storage-provider = ["dep:async-trait"]
-c-api = ["dep:glib-sys", "dep:libc"]
+c-api = ["dep:libc"]
 
 [dependencies]
 arrayvec = "0.5.2"
@@ -34,7 +34,6 @@ async-trait = { version = "0.1.64", optional = true }
 bamboo-rs-core-ed25519-yasmf = "0.1.1"
 ciborium = "0.2.0"
 ed25519-dalek = "1.0.1"
-glib-sys = { version = "0.18.1", optional = true }
 hex = { version = "0.4.3", features = ["serde"] }
 libc = {version = "0.2.150", optional = true }
 lipmaa-link = "0.2.2"

--- a/p2panda-rs/src/gobject_introspection/entry.rs
+++ b/p2panda-rs/src/gobject_introspection/entry.rs
@@ -1,9 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-extern crate libc;
-
-use glib_sys::g_strdup;
-use libc::c_char;
+use libc::{c_char, strdup};
 use std::ffi::CStr;
 use std::ffi::CString;
 
@@ -123,8 +120,8 @@ pub extern "C" fn p2panda_sign_and_encode_entry(
     .unwrap();
 
     // Return result as a hexadecimal string
-    let c_string = CString::new(entry_encoded.to_string().as_str()).unwrap();
-    unsafe { g_strdup(c_string.as_ptr()) }
+    let c_string: CString = CString::new(entry_encoded.to_string().as_str()).unwrap();
+    unsafe { strdup(c_string.as_ptr()) }
 }
 
 /// p2panda_decode_entry:

--- a/p2panda-rs/src/gobject_introspection/entry.rs
+++ b/p2panda-rs/src/gobject_introspection/entry.rs
@@ -120,7 +120,7 @@ pub extern "C" fn p2panda_sign_and_encode_entry(
     .unwrap();
 
     // Return result as a hexadecimal string
-    let c_string: CString = CString::new(entry_encoded.to_string().as_str()).unwrap();
+    let c_string = CString::new(entry_encoded.to_string().as_str()).unwrap();
     unsafe { strdup(c_string.as_ptr()) }
 }
 

--- a/p2panda-rs/src/gobject_introspection/hash.rs
+++ b/p2panda-rs/src/gobject_introspection/hash.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-use glib_sys::g_strdup;
-use libc::c_char;
+use libc::{c_char, strdup};
 use std::ffi::CStr;
 use std::ffi::CString;
 
@@ -25,5 +24,5 @@ pub extern "C" fn p2panda_generate_hash(value: *const c_char) -> *mut c_char {
     // Hash the value and return it as a string
     let hash = crate::hash::Hash::new_from_bytes(&bytes);
     let c_string = CString::new(hash.to_string()).unwrap();
-    unsafe { g_strdup(c_string.as_ptr()) }
+    unsafe { strdup(c_string.as_ptr()) }
 }

--- a/p2panda-rs/src/gobject_introspection/key_pair.rs
+++ b/p2panda-rs/src/gobject_introspection/key_pair.rs
@@ -1,13 +1,12 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+use libc::{c_char, c_int, strdup};
 use std::{
     convert::TryFrom,
     ffi::{CStr, CString},
 };
 
 use ed25519_dalek::Signature;
-use glib_sys::g_strdup;
-use libc::{c_char, c_int};
 
 use crate::identity::{KeyPair as KeyPairNonC, PublicKey};
 
@@ -59,7 +58,7 @@ pub extern "C" fn p2panda_key_pair_get_public_key(instance: *mut KeyPair) -> *mu
     };
     let key = key_pair.0.public_key().to_bytes();
     let c_string = CString::new(key).unwrap();
-    unsafe { g_strdup(c_string.as_ptr()) }
+    unsafe { strdup(c_string.as_ptr()) }
 }
 
 #[no_mangle]
@@ -70,7 +69,7 @@ pub extern "C" fn p2panda_key_pair_get_private_key(instance: *mut KeyPair) -> *m
     };
     let key = key_pair.0.private_key().to_bytes();
     let c_string = CString::new(key).unwrap();
-    unsafe { g_strdup(c_string.as_ptr()) }
+    unsafe { strdup(c_string.as_ptr()) }
 }
 
 #[no_mangle]
@@ -90,7 +89,7 @@ pub extern "C" fn p2panda_key_pair_sign(
 
     let signature = key_pair.0.sign(c_str.to_str().unwrap().as_bytes());
     let c_string = CString::new(signature.to_bytes()).unwrap();
-    unsafe { g_strdup(c_string.as_ptr()) }
+    unsafe { strdup(c_string.as_ptr()) }
 }
 
 #[no_mangle]


### PR DESCRIPTION
While looking at your changes, I realized that you imported glib for string duplication. I think that it would better to use the standard C variant, as it removes the dependency on the system library.

What do you think?